### PR TITLE
enhancement: upgrade tsconfig to use es2020.

### DIFF
--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,14 +1,16 @@
 {
   "compilerOptions": {
-    "target": "es5"
+    "target": "es2021"
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs"
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": [
+      "es2021",
       "es5",
-      "es6"
     ]
     /* Specify library files to be included in the compilation. */,
+    "allowJs": true,
+    /* Needed for es2020 apollon dependency */
     "outDir": "../../build/server",
     /* Strict Type-Checking Options */
     "noImplicitAny": true

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
+    "module": "es2020",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "jsx": "react",
     "declaration": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
+    "module": "es2020",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "dom"],
     "jsx": "react",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
**What**:

Update typescript configuration to make use of es2021.
Preparing the package/server to include the es2020 output of the apollon dependency.



**Why**:

As the Apollon repository got updated to get build as esmodule instead commonjs after the update to es2021, we have to adjust Apollon_standalone to be able to integrate apollon.
