### PR TITLE
enhancement: include new lib/es6 output of apollon. 

### DIFF
--- a/packages/webapp/src/main/services/editor-options/editor-options-reducer.ts
+++ b/packages/webapp/src/main/services/editor-options/editor-options-reducer.ts
@@ -2,7 +2,7 @@ import { Reducer } from 'redux';
 import { Actions } from '../actions';
 import { EditorOptions, EditorOptionsActionTypes } from './editor-options-types';
 import { UMLDiagramType } from '@ls1intum/apollon';
-import { ApollonMode, Locale } from '@ls1intum/apollon/lib/services/editor/editor-types';
+import { ApollonMode, Locale } from '@ls1intum/apollon/lib/es6/services/editor/editor-types';
 
 export const defaultEditorOptions: EditorOptions = {
   type: UMLDiagramType.ClassDiagram,

--- a/packages/webapp/src/main/services/editor-options/editor-options-types.ts
+++ b/packages/webapp/src/main/services/editor-options/editor-options-types.ts
@@ -1,7 +1,7 @@
 import { Action, DeepPartial } from 'redux';
 import { UMLDiagramType } from '@ls1intum/apollon';
-import { ApollonMode, Locale } from '@ls1intum/apollon/lib/services/editor/editor-types';
-import { Styles } from '@ls1intum/apollon/lib/components/theme/styles';
+import { ApollonMode, Locale } from '@ls1intum/apollon/lib/es6/services/editor/editor-types';
+import { Styles } from '@ls1intum/apollon/lib/es6/components/theme/styles';
 
 export type EditorOptions = {
   type: UMLDiagramType;

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
+    "module": "es2020",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
+    "module": "es2020",
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2021", "es2017", "dom"],
     "jsx": "react",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
### Motivation and Context

This PR handles integration of changes in https://github.com/ls1intum/Apollon/pull/204 .
Apollon now provides output in lib/es5 and lib/es6.
We want to also upgrade our typescript to produce es2020 output.

### Description

I adjusted two required paths to consume from apollon/lib/es6.
I upgraded the root and webapp tsconfig to produce es2020 output

### Steps for Testing

These changes should be tested in conjunction with my Apollon PR (https://github.com/ls1intum/Apollon/pull/204).

Steps:
1. Inside Apollon repository:
   1.1. checkout the `enhancement/create_additional_es5_output ` in apollon.
   1.2. `rm -rf node_modules && yarn install && yarn prepare`
   1.3. `yarn link`
2. Inside Apollon_standalone
   2.1. checkout the `enhancement/include_es6_apollon `  branch
   2.2. ` yarn install && yarn link "@ls1intum/apollon" && yarn start`

The webapp should be running normally now. 
When checking the source files inside the browser you can see that the Apollon webapp uses the files from lib/es6.
the typescript output of the webapp should be es2020, you can check this by adding an `outputDir` to the `packages/webapp/tsconfig.json ` and running `tsc -p ./packages/webapp/tsconfig.json`