### PR TITLE
Create a docker file and github action for Apollon Standalone

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,74 @@
+name: Build and Push
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+      - release/*
+    tags: '*'
+  release:
+    types:
+      - created
+
+jobs:
+  buildx:
+    name: Build and Push the Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute Tag
+        uses: actions/github-script@v6
+        id: compute-tag
+        with:
+          result-encoding: string
+          script: |
+            if (context.eventName === "pull_request") {
+              return "pr-" + context.issue.number;
+            }
+            if (context.eventName === "push") {
+              if (context.ref.startsWith("refs/tags/")) {
+                return context.ref.slice(10);
+              }
+              if (context.ref === "refs/heads/main") {
+                return "stable";
+              }
+              if (context.ref === "refs/heads/develop") {
+                return "latest";
+              }
+            }
+            return "FALSE";
+
+      - uses: actions/checkout@v2
+
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      -
+        name: Install Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          version: latest
+
+      -
+        name: Build Image and Push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        if: ${{ steps.compute-tag.outputs.result != 'FALSE' }}
+        with:
+          context: .
+          tags: ghcr.io/ls1intum/apollon_standalone:${{ steps.compute-tag.outputs.result }}
+          platforms: linux/amd64,linux/arm64/v8
+          push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -70,5 +70,5 @@ jobs:
         with:
           context: .
           tags: ghcr.io/ls1intum/apollon_standalone:${{ steps.compute-tag.outputs.result }}
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64
           push: true


### PR DESCRIPTION
# Motivation and Context
Apollon Standalone Docker image was not working, so we updated the Dockerfile.

# Description
Added a Dockerfile and a GitHub action for building and pushing the image to ghcr.io.

# Steps for Testing
```
docker run -it --rm -p 8080:8080 ghcr.io/ls1intum/apollon_standalone:pr-29
```