### PR TITLE
``Development``: Fix for darkmode issues

### DIFF
--- a/packages/webapp/src/main/styles.css
+++ b/packages/webapp/src/main/styles.css
@@ -242,6 +242,10 @@ input:checked + .slider:before {
   color: var(--apollon-background-inverse);
 }
 
+.Toastify__close-button--light {
+  color: var(--apollon-background-inverse);
+}
+
 .btn-outline-secondary {
   color: var(--apollon-btn-outline-secondary-color);
   border-color: var(--apollon-btn-outline-secondary-color);

--- a/packages/webapp/src/main/themings.json
+++ b/packages/webapp/src/main/themings.json
@@ -23,7 +23,7 @@
     "--apollon-primary": "#3e8acc",
     "--apollon-primary-contrast": "white",
     "--apollon-secondary": "#888",
-    "--apollon-alert-warning-yellow": "#f39c12",
+    "--apollon-alert-warning-yellow": "#ffffff",
     "--apollon-alert-warning-background": "#f39c12",
     "--apollon-alert-warning-border": "#000000",
     "--apollon-background": "#181a18",


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR fixes a couple of dark mode issues in Standalone.
- Warning text in firefox is now visible in dark mode.
- Close icon of toaster is now visible in darkmode.

Issue Number: https://github.com/ls1intum/Apollon_standalone/issues/40

### Steps for Testing
#### In test server
- Goto [test server](https://test1.apollon.ase.in.tum.de/) in Firefox browser.
- Set the application to dark mode.
- Observe that the warning text is now visible.
- Share the diagram and observe that the close icon of the toaster is now visible in dark mode, as illustrated in screenshots.


### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/14681902/180646343-2ca5e65f-871b-44e7-b869-58aa134c4f05.png)
![image](https://user-images.githubusercontent.com/14681902/180646357-1ee37510-6c83-405f-aaa9-f6893381fe78.png)

#### After
![image](https://user-images.githubusercontent.com/14681902/180646333-0386a397-2f42-4f24-a74e-4ef02c929562.png)
![image](https://user-images.githubusercontent.com/14681902/180646368-2da4c783-bf3c-4dd1-94c9-b094606b48ad.png)

