### PR TITLE
`Development`: Export PNGs with Transparent/White Background

### DIFF
--- a/packages/webapp/src/main/components/application-bar/menues/file-menu.tsx
+++ b/packages/webapp/src/main/components/application-bar/menues/file-menu.tsx
@@ -72,14 +72,17 @@ class FileMenuComponent extends Component<OwnProps, State> {
     event.stopPropagation();
   };
 
-  exportDiagram(exportType: 'PNG' | 'SVG' | 'JSON' | 'PDF'): void {
+  exportDiagram(exportType: 'PNG' | 'PNG_WHITE' | 'SVG' | 'JSON' | 'PDF'): void {
     if (this.props.editor && this.props.diagram?.title) {
       switch (exportType) {
         case 'SVG':
           this.props.exportAsSVG(this.props.editor, this.props.diagram?.title);
           break;
+        case 'PNG_WHITE':
+          this.props.exportAsPNG(this.props.editor, this.props.diagram?.title, true);
+          break;
         case 'PNG':
-          this.props.exportAsPNG(this.props.editor, this.props.diagram?.title);
+          this.props.exportAsPNG(this.props.editor, this.props.diagram?.title, false);
           break;
         case 'PDF':
           this.props.exportAsPDF(this.props.editor, this.props.diagram?.title);
@@ -118,7 +121,12 @@ class FileMenuComponent extends Component<OwnProps, State> {
             </Dropdown.Toggle>
             <Dropdown.Menu>
               <Dropdown.Item onClick={(event: any) => this.exportDiagram('SVG')}>As SVG</Dropdown.Item>
-              <Dropdown.Item onClick={(event: any) => this.exportDiagram('PNG')}>As PNG</Dropdown.Item>
+              <Dropdown.Item onClick={(event: any) => this.exportDiagram('PNG_WHITE')}>
+                As PNG (White Background)
+              </Dropdown.Item>
+              <Dropdown.Item onClick={(event: any) => this.exportDiagram('PNG')}>
+                As PNG (Transparent Background)
+              </Dropdown.Item>
               <Dropdown.Item onClick={(event: any) => this.exportDiagram('JSON')}>As JSON</Dropdown.Item>
               <Dropdown.Item onClick={(event: any) => this.exportDiagram('PDF')}>As PDF</Dropdown.Item>
             </Dropdown.Menu>

--- a/packages/webapp/src/main/services/export/export-repository.ts
+++ b/packages/webapp/src/main/services/export/export-repository.ts
@@ -10,11 +10,12 @@ export const ExportRepository = {
       diagramTitle,
     },
   }),
-  exportAsPNG: (editor: ApollonEditor, diagramTitle: string): ExportPNGAction => ({
+  exportAsPNG: (editor: ApollonEditor, diagramTitle: string, setWhiteBackground: boolean): ExportPNGAction => ({
     type: ExportActionTypes.EXPORT_PNG,
     payload: {
       editor,
       diagramTitle,
+      setWhiteBackground,
     },
   }),
   exportAsJSON: (editor: ApollonEditor, diagram: Diagram): ExportJSONAction => ({

--- a/packages/webapp/src/main/services/export/export-types.ts
+++ b/packages/webapp/src/main/services/export/export-types.ts
@@ -22,6 +22,7 @@ export type ExportPNGAction = Action<ExportActionTypes.EXPORT_PNG> & {
     // needs reference to ApollonEditor to perform export
     editor: ApollonEditor;
     diagramTitle: string;
+    setWhiteBackground: boolean;
   };
 };
 

--- a/packages/webapp/src/main/services/export/png/export-png-epics.ts
+++ b/packages/webapp/src/main/services/export/png/export-png-epics.ts
@@ -15,8 +15,9 @@ export const exportPNGEpic: Epic<Action, FileDownloadAction, ApplicationState> =
       const apollonEditor: ApollonEditor = action.payload.editor;
       const fileName: string = `${action.payload.diagramTitle}.png`;
       const apollonSVG: SVG = apollonEditor.exportAsSVG();
+      const setWhiteBackground: boolean = action.payload.setWhiteBackground;
       return from(
-        convertRenderedSVGToPNG(apollonSVG).then((png: Blob) => {
+        convertRenderedSVGToPNG(apollonSVG, setWhiteBackground).then((png: Blob) => {
           const fileToDownload = new File([png], fileName);
           return {
             type: FileDownloadActionTypes.FILE_DOWNLOAD,
@@ -31,7 +32,7 @@ export const exportPNGEpic: Epic<Action, FileDownloadAction, ApplicationState> =
   );
 };
 
-export function convertRenderedSVGToPNG(renderedSVG: SVG): Promise<Blob> {
+export function convertRenderedSVGToPNG(renderedSVG: SVG, whiteBackground: boolean): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const { width, height } = renderedSVG.clip;
 
@@ -54,6 +55,12 @@ export function convertRenderedSVGToPNG(renderedSVG: SVG): Promise<Blob> {
       canvas.height = height * scale;
 
       const context = canvas.getContext('2d')!;
+
+      if (whiteBackground) {
+        context.fillStyle = 'white';
+        context.fillRect(0, 0, canvas.width, canvas.height);
+      }
+
       context.scale(scale, scale);
       context.drawImage(image, 0, 0);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This PR allows users to export their diagram in PNG with white as well as transparent background.


### Steps for Testing
#### In test server
1. Goto [test server](https://test1.apollon.ase.in.tum.de/).
2. Add couple of elements in the canvas
3. Export the diagram with transparent background by clicking on File > Export > As PNG (Transparent Background)
4. Export the diagram with white background by clicking on File > Export > As PNG (White Background)
5. Verify the exported diagrams are exported correctly (with selected backgrounds type).

### Screenshots
![screen-capture (12)](https://user-images.githubusercontent.com/14681902/183063767-f1c58699-749d-4208-9140-dd0f25627b78.gif)



