### PR TITLE
`Development`: Restrict users from sharing empty diagram

### DIFF
--- a/packages/webapp/src/main/components/modals/share-modal/share-modal.tsx
+++ b/packages/webapp/src/main/components/modals/share-modal/share-modal.tsx
@@ -84,7 +84,7 @@ class ShareModalComponent extends Component<Props, State> {
   };
 
   publishDiagram = () => {
-    if (this.props.diagram) {
+    if (this.props.diagram && this.props.diagram.model && this.props.diagram.model.elements.length > 0) {
       DiagramRepository.publishDiagramOnServer(this.props.diagram)
         .then((token: string) => {
           this.setState({ token }, () => {
@@ -107,6 +107,13 @@ class ShareModalComponent extends Component<Props, State> {
           // tslint:disable-next-line:no-console
           console.error(error);
         });
+    } else {
+      this.props.createError(
+        ErrorActionType.DISPLAY_ERROR,
+        'Sharing diagram failed',
+        'You are trying to share an empty diagram. Please insert at least one element to the canvas before sharing.',
+      );
+      this.handleClose();
     }
   };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Apollon! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Previously users were allowed to share empty diagrams and were notified with an "import error" message only after accessing the shared URL.
The error message was generic and did not make sense while sharing an empty diagram.
This PR restricts users from sharing empty diagrams in the first place. 

### Steps for Testing
#### Test Server
- Deploy branch `enhancement/disable-sharing-empty-diagram` to the test server
- Goto [test server](https://test1.apollon.ase.in.tum.de/) once its deployed
- Try sharing the empty diagram 
- Observe that the sharing fails and the user is notified with an error message.


### Screenshots
#### Before
<img width="1511" alt="image (1)" src="https://user-images.githubusercontent.com/14681902/207602064-df728a65-0969-4ca2-aa8d-8efdb916e34a.png">


#### After
![screen-capture (3)](https://user-images.githubusercontent.com/14681902/207601933-26c6dca3-3964-478d-b8f8-9d8e15c7c468.gif)

