### PR TITLE
Fix Apollon Conversion Service fails with error because of uninitialised redux store

### DIFF
--- a/packages/server/src/main/services/conversion-service/conversion-service.ts
+++ b/packages/server/src/main/services/conversion-service/conversion-service.ts
@@ -16,9 +16,9 @@ export class ConversionService {
 
     const container = document.querySelector('div')!;
     const editor = new ApollonEditor(container, {});
-
+    await editor.nextRender;
     editor.model = model;
-
+    await editor.nextRender;
     return editor.exportAsSVG();
   };
 }


### PR DESCRIPTION
We now await till the next render cycle of Apollon and the redux store is initialized to avoid these errors.
This PR only makes the Apollon Conversion Service run again. It does not solve the issue with incorrectly rendering Apollon diagrams from Artemis.