### PR TITLE
Resolve issues with the conversion service exiting unexpectedly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ARG build_dir=/build_application
 
 # first stage which builds the application
-FROM node:14
+FROM node:18
 
 ARG build_dir
 ENV DEPLOYMENT_URL="http://localhost:8080"
@@ -17,7 +17,7 @@ RUN yarn install
 RUN yarn build
 
 # second stage which creates the container image to run the application
-FROM node:14
+FROM node:16
 
 RUN apt-get update && apt-get -y install cron
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,7 +14,7 @@
     "cors": "2.8.5",
     "express": "4.18.2",
     "jsdom": "22.1.0",
-    "jsdom-global": "3.0.2",
+    "global-jsdom": "9.1.0 ",
     "pdfmake": "0.2.7",
     "shared": "1.7.2"
   },

--- a/packages/server/src/main/services/conversion-service/conversion-service.ts
+++ b/packages/server/src/main/services/conversion-service/conversion-service.ts
@@ -1,4 +1,4 @@
-import 'jsdom-global/register';
+import 'global-jsdom/register';
 import { ApollonEditor, SVG, UMLModel } from '@ls1intum/apollon';
 
 export class ConversionService {


### PR DESCRIPTION
This PR attempts to solve the issues with the conversion service exiting with an error code when attempting to export a Apollon diagram as SVG.

The issue seems to be the initialization of the package JSDOM. The package used for initilization previously (jsdom-global) is no longer maintained and has last been updated in 2017. The replacement package "global-jsdom" seems to resolve this issue.

I additionally updated the node version of the Docker image as the global-jsdom package expects a minimum version of node 18.