### PR TITLE
Add support for Apollon 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2350,81 +2350,6 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
-    "node_modules/@ls1intum/apollon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-3.1.0.tgz",
-      "integrity": "sha512-QxuknwxiJKUiEr7VE+jGTOjdwnCwQYh40SN9V9jilGuT2kOSgBLARLEwpOelqZDZd9KSJGEtMasSIRIupvO7Xg==",
-      "dependencies": {
-        "fast-json-patch": "3.1.1",
-        "is-mobile": "4.0.0",
-        "pepjs": "0.5.3",
-        "react": "18.2.0",
-        "react-color": "2.19.3",
-        "react-dom": "18.2.0",
-        "react-redux": "8.1.3",
-        "react-tooltip": "4.5.1",
-        "redux": "4.2.1",
-        "redux-saga": "1.2.3",
-        "redux-thunk": "2.4.2",
-        "rxjs": "7.8.1",
-        "styled-components": "5.3.11",
-        "tslib": "2.6.2",
-        "uuid": "9.0.1"
-      }
-    },
-    "node_modules/@ls1intum/apollon/node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
-    "node_modules/@ls1intum/apollon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@ls1intum/apollon/node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
-    "node_modules/@ls1intum/apollon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -13980,7 +13905,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ls1intum/apollon": "3.1.0",
+        "@ls1intum/apollon": "3.3.1",
         "moment": "2.29.4",
         "ws": "8.14.2"
       },
@@ -13988,10 +13913,88 @@
         "node": ">=18.17.0"
       }
     },
+    "packages/shared/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "packages/shared/node_modules/@ls1intum/apollon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-3.3.1.tgz",
+      "integrity": "sha512-qT5BHyAyj2rA1QqwOX71onWxMfrRAAcCCCFPdNdVMOqRs6WiH2gatbYJ6+kGYQosRgp6KlPTyzO3tZPUB6pEZA==",
+      "dependencies": {
+        "fast-json-patch": "3.1.1",
+        "is-mobile": "4.0.0",
+        "pepjs": "0.5.3",
+        "react": "18.2.0",
+        "react-color": "2.19.3",
+        "react-dom": "18.2.0",
+        "react-redux": "8.1.3",
+        "react-tooltip": "4.5.1",
+        "redux": "4.2.1",
+        "redux-saga": "1.2.3",
+        "redux-thunk": "2.4.2",
+        "rxjs": "7.8.1",
+        "styled-components": "5.3.11",
+        "tslib": "2.6.2",
+        "uuid": "9.0.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "packages/shared/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/shared/node_modules/styled-components": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "packages/shared/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "packages/webapp": {
       "version": "2.0.0",
       "dependencies": {
-        "@ls1intum/apollon": "3.1.0",
+        "@ls1intum/apollon": "3.3.1",
         "@sentry/react": "7.81.1",
         "bootstrap": "5.3.2",
         "moment": "2.29.4",
@@ -14052,6 +14055,84 @@
       },
       "engines": {
         "node": ">=18.17.0"
+      }
+    },
+    "packages/webapp/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "packages/webapp/node_modules/@ls1intum/apollon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-3.3.1.tgz",
+      "integrity": "sha512-qT5BHyAyj2rA1QqwOX71onWxMfrRAAcCCCFPdNdVMOqRs6WiH2gatbYJ6+kGYQosRgp6KlPTyzO3tZPUB6pEZA==",
+      "dependencies": {
+        "fast-json-patch": "3.1.1",
+        "is-mobile": "4.0.0",
+        "pepjs": "0.5.3",
+        "react": "18.2.0",
+        "react-color": "2.19.3",
+        "react-dom": "18.2.0",
+        "react-redux": "8.1.3",
+        "react-tooltip": "4.5.1",
+        "redux": "4.2.1",
+        "redux-saga": "1.2.3",
+        "redux-thunk": "2.4.2",
+        "rxjs": "7.8.1",
+        "styled-components": "5.3.11",
+        "tslib": "2.6.2",
+        "uuid": "9.0.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
+    "packages/webapp/node_modules/@ls1intum/apollon/node_modules/styled-components": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "packages/webapp/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "packages/webapp/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     }
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@ls1intum/apollon": "3.1.0",
+    "@ls1intum/apollon": "3.3.1",
     "moment": "2.29.4",
     "ws": "8.14.2"
   },

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ls1intum/apollon": "3.1.0",
+    "@ls1intum/apollon": "3.3.1",
     "@sentry/react": "7.81.1",
     "bootstrap": "5.3.2",
     "moment": "2.29.4",

--- a/packages/webapp/src/main/components/apollon-editor-component/apollon-editor-component.tsx
+++ b/packages/webapp/src/main/components/apollon-editor-component/apollon-editor-component.tsx
@@ -28,6 +28,7 @@ const ApollonContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 2;
+  overflow: hidden;
 `;
 
 type OwnProps = {};

--- a/packages/webapp/src/main/styles.css
+++ b/packages/webapp/src/main/styles.css
@@ -23,6 +23,7 @@ body {
   flex-direction: column;
   flex-grow: 1;
   background-color: var(--apollon-background);
+  height: 100%;
 }
 
 .apollon-editor {


### PR DESCRIPTION
This PR adds support for Apollon 3.3.1.

To get the sidebar to overflow and scroll correctly, a few CSS adaptions have to be made.

<img width="1390" alt="Screenshot 2023-11-27 at 17 56 16" src="https://github.com/ls1intum/Apollon_standalone/assets/143808484/e93b1306-78d1-4b78-8616-4d87826cef86">
