### PR TITLE
More stable persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,6 +3749,14 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/audit-debounce": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/audit-debounce/-/audit-debounce-0.1.1.tgz",
+      "integrity": "sha512-9YZHlk3xEKQhjjLKV46eN9krs0dtW/JM1Ech3+4twQfcpYvlyToiJCMW3ugfPJgrrDtE+wwxGPjBlYlethO7wA==",
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "dev": true,
@@ -9778,7 +9786,8 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -12587,6 +12596,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/node": "7.91.0",
+        "audit-debounce": "^0.1.1",
         "body-parser": "1.20.2",
         "canvas": "2.11.2",
         "cors": "2.8.5",
@@ -12594,6 +12604,7 @@
         "global-jsdom": "9.2.0",
         "jsdom": "23.0.1",
         "pdfmake": "0.2.8",
+        "rxjs": "^7.8.1",
         "shared": "2.1.1"
       },
       "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@sentry/node": "7.91.0",
+    "audit-debounce": "0.1.1",
     "body-parser": "1.20.2",
     "canvas": "2.11.2",
     "cors": "2.8.5",
@@ -20,6 +21,7 @@
     "global-jsdom": "9.2.0",
     "jsdom": "23.0.1",
     "pdfmake": "0.2.8",
+    "rxjs": "7.8.1",
     "shared": "2.1.1"
   },
   "devDependencies": {

--- a/packages/server/src/main/services/diagram-storage/diagram-file-storage-service.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-file-storage-service.ts
@@ -1,22 +1,127 @@
+import { Subject, groupBy, mergeMap, switchMap, from, debounceTime } from 'rxjs';
+import { auditDebounceTime } from 'audit-debounce';
+
 import { FileStorageService } from '../storage-service/file-storage-service';
 import { DiagramDTO } from '../../../../../shared/src/main/diagram-dto';
 import { diagramStoragePath } from '../../constants';
 import { DiagramStorageService } from './diagram-storage-service';
 
+
+interface SaveRequest {
+  diagramDTO: DiagramDTO;
+  token: string;
+  path: string;
+}
+
+
 export class DiagramFileStorageService implements DiagramStorageService {
+  /**
+   * How long should a substream for handling save requests of a particular
+   * diagram be kept alive. Recommended value is larger that SAVE_INTERVAL.
+   */
+  static readonly SAVE_GROUP_TTL = 10_000;
+  /**
+   * How long should we wait for incoming save requests before saving the diagram.
+   */
+  static readonly SAVE_DEBOUNCE_TIME = 500;
+  /**
+   * How often should we save the diagram to ensure we don't lose data.
+   * Saves might occur at a faster rate, this determines the maximum wait
+   * between two saves (when there are save requests).
+   */
+  static readonly SAVE_INTERVAL = 3_000;
+
   private fileStorageService: FileStorageService = new FileStorageService();
 
-  saveDiagram(diagramDTO: DiagramDTO, token: string, shared: boolean = false): Promise<string> {
+  //
+  // this router handles saving of diagrams.
+  // requests for saving diagrams can come at any time, and might
+  // need some pacing to avoid overloading the file system (which results in corrupted files.
+  //
+  private router = new Subject<SaveRequest>();
+
+  constructor() {
+    //
+    // I do realize complex rxjs pipelines are not the easiest to read.
+    // so I will try to explain what is going on here.
+    //
+    this.router.pipe(
+      //
+      // first, we group requests by token, since we don't want
+      // save requests for one token to affect requests of another
+      // token on the server (each token relates to a different diagram)
+      //
+      groupBy(
+        (request) => request.token,
+        {
+          //
+          // this duration selector determines how long the "group" stream
+          // should be kept alive. without a duration selector, these "groups"
+          // will be kept alive indefinitely, clogging up memory.
+          //
+          duration: (group) => group.pipe(
+            //
+            // indicates that each group should be kept alive
+            // SAVE_GROUP_TTL milliseconds after the last save request for that
+            // group. note that the diagram might still be worked on,
+            // but we can create a new group for new save requests if they happen.
+            //
+            debounceTime(DiagramFileStorageService.SAVE_GROUP_TTL)
+          )
+        }
+      ),
+      //
+      // with `mergeMap()`, we will operate on each "group" independently
+      // and then merge the results back into a singular stream.
+      //
+      mergeMap((group) => group.pipe(
+        //
+        // this will try to wait for SAVE_DEBOUNCE_TIME milliseconds
+        // after each incoming save request before saving the diagram.
+        // since that can be too long if save requests are incoming frequently,
+        // we will also save the diagram every SAVE_INTERVAL milliseconds to ensure
+        // we don't lose data (in case the server process stops, for example due to a crash).
+        //
+        auditDebounceTime(
+          DiagramFileStorageService.SAVE_DEBOUNCE_TIME,
+          DiagramFileStorageService.SAVE_INTERVAL,
+        ),
+        //
+        // since saving is an async operation itself, we need to use `switchMap()`
+        // to ensure only a single save operation is running at any given time.
+        //
+        // FIXME: this requires cancellation  mechanism on file storage, which is not implemented yet.
+        // read [this](https://stackoverflow.com/questions/74529131/node-js-how-to-cancel-a-writefile-operation)
+        // to learn how to cancel a write operation.
+        //
+        switchMap((request) => {
+          return from(
+            this.fileStorageService
+              .saveContentToFile(request.path, JSON.stringify(request.diagramDTO))
+          )
+        }),
+      ))
+    ).subscribe();
+  }
+
+  async saveDiagram(diagramDTO: DiagramDTO, token: string, shared: boolean = false): Promise<string> {
     // alpha numeric token with length = tokenLength
     const path = this.getFilePathForToken(token);
-    return this.fileStorageService.doesFileExist(path).then((exists) => {
-      if (exists && !shared) {
-        throw Error(`File at ${path} already exists`);
+    const exists = await this.fileStorageService.doesFileExist(path);
+
+    if (exists && !shared) {
+      throw Error(`File at ${path} already exists`);
+    } else {
+      if (exists) {
+        this.router.next({ diagramDTO, token, path });
       } else {
-        return this.fileStorageService.saveContentToFile(path, JSON.stringify(diagramDTO)).then(() => token);
+        await this.fileStorageService.saveContentToFile(path, JSON.stringify(diagramDTO));
       }
-    });
+
+      return token;
+    }
   }
+
   getDiagramByLink(token: string): Promise<DiagramDTO | undefined> {
     const path = this.getFilePathForToken(token);
     return this.fileStorageService.getFileContent(path).then((fileContent) => JSON.parse(fileContent) as DiagramDTO);


### PR DESCRIPTION
Currently, the file storage for diagrams acts eagerly, i.e. the diagram file is written to anytime a client makes a change to the diagram. When changes become frequent, this results in corrupted files (as changes overlap each other), and subsequently result in the server process crashing.

With this change, writing to diagram files is paced to avoid this issue. Non-existent files are still saved eagerly, but already existing files will have a debounce before being saved (currently `500ms`, configurable). In scenarios where the diagram is being updated rapidly (e.g. multiple peers, continuous sync, etc) this can cause long waits before saving a diagram, which increases the risk of data loss in case of unforeseen crashes. To mitigate this issue, I've ensured that when there are rapid changes, there is a maximum wait between saves as well (currently `3s`, configurable).

p.s. To facilitate this behaviour, I've used a [custom operator](https://github.com/loreanvictor/audit-debounce), whose code I can inline in this project as well (I think personally it should be a separate code as it is independent of Apollon_standalone, but would understand the decision to inline it as well).