### PR TITLE
suppress self-stuttering

### DIFF
--- a/packages/webapp/src/main/utils/patch-verifier.ts
+++ b/packages/webapp/src/main/utils/patch-verifier.ts
@@ -2,21 +2,61 @@ import { Patch } from '@ls1intum/apollon'
 import { Operation, ReplaceOperation } from 'fast-json-patch'
 
 
+/**
+ * A signed replace operation is a replace operation with an additional hash property.
+ * This enables tracing the origin of a replace operation.
+ */
 export type SignedReplaceOperation = ReplaceOperation<any> & { hash: string };
+
+/**
+ * A signed operation is either a replace operation with a hash property or any other operation.
+ * The hash property is used to verify the origin of a replace operation.
+ * Only replace operations need a hash property.
+ */
 export type SignedOperation = Exclude<Operation, ReplaceOperation<any>> | SignedReplaceOperation;
+
+/**
+ * A signed patch is a patch where all replace operations are signed, i.e.
+ * all the replace operations have a hash allowing for tracing their origin.
+ */
 export type SignedPatch = SignedOperation[];
 
-function isReplaceOperation(operation: Operation): operation is ReplaceOperation<any> {
+/**
+ * @param operation
+ * @returns true if the operation is a replace operation, false otherwise
+ */
+export function isReplaceOperation(operation: Operation): operation is ReplaceOperation<any> {
   return operation.op === 'replace';
 }
 
-function isSignedOperation(operation: Operation): operation is SignedOperation {
+/**
+ * @param operation 
+ * @returns true if the operation is a signed operation, false otherwise. A signed operation is either
+ * a replace operation with a hash property or any other operation.
+ */
+export function isSignedOperation(operation: Operation): operation is SignedOperation {
   return !isReplaceOperation(operation) || 'hash' in operation;
 }
 
+/**
+ * A patch verifier enables otpimisitc discard of incomging changes.It can be used to sign
+ * each operation (or opeerations of each patch) and track them. If the server broadcasts changes
+ * of the same scope (e.g. the same path) before re-broadcasting that particular change, the client
+ * can safely discard the change as it will (optimistically) be overridden when the server re-broadcasts
+ * the tracked change.
+ * 
+ * This greatly helps with stuttering issues due to clients constantly re-applying changes they have
+ * already applied locally but in a different order. See
+ * [**this issue**](https://github.com/ls1intum/Apollon_standalone/pull/70) for more details.
+ */
 export class PatchVerifier {
   private waitlist: { [address: string]: string } = {};
 
+  /**
+   * Signs an operation and tracks it. Only replace operations are signed and tracked.
+   * @param operation 
+   * @returns The signed version of the operation (to be sent to the server)
+   */
   public signOperation(operation: Operation): SignedOperation {
     if (isReplaceOperation(operation)) {
       const hash = Math.random().toString(36).substring(2, 15);
@@ -29,10 +69,29 @@ export class PatchVerifier {
     }
   }
 
+  /**
+   * Signs all operations inside the patch.
+   * @param patch 
+   * @returns the signed patch (to be sent to the server)
+   */
   public sign(patch: Patch) {
     return patch.map(op => this.signOperation(op));
   }
 
+  /**
+   * Checks whether the operation should be applied or should it be optimisitcally discarded.
+   * - If the operation is not a replace operation, it is always applied.
+   * - If the operation is a replace operation but it is not signed, it is always applied.
+   * - If the operation is a signed replace operation and no other operation with the same path is tracked,
+   *   it will be applied.
+   * - Otherwise it will be discarded.
+   * 
+   * If it receives an operation that is already tracked, it will be discarded, and the
+   * operation will be untracked (so following operations on the same path will be applied).
+   * 
+   * @param operation 
+   * @returns true if the operation should be applied, false if it should be discarded.
+   */
   public isVerifiedOperation(operation: Operation): boolean {
     if (
       isReplaceOperation(operation)
@@ -49,6 +108,11 @@ export class PatchVerifier {
     }
   }
 
+  /**
+   * Filters an incoming patch, only leaving the operations that should be applied.
+   * @param patch 
+   * @returns a patch with operations that should be applied.
+   */
   public verified(patch: Patch): Patch {
     return patch.filter(op => this.isVerifiedOperation(op));
   }

--- a/packages/webapp/src/main/utils/patch-verifier.ts
+++ b/packages/webapp/src/main/utils/patch-verifier.ts
@@ -1,0 +1,55 @@
+import { Patch } from '@ls1intum/apollon'
+import { Operation, ReplaceOperation } from 'fast-json-patch'
+
+
+export type SignedReplaceOperation = ReplaceOperation<any> & { hash: string };
+export type SignedOperation = Exclude<Operation, ReplaceOperation<any>> | SignedReplaceOperation;
+export type SignedPatch = SignedOperation[];
+
+function isReplaceOperation(operation: Operation): operation is ReplaceOperation<any> {
+  return operation.op === 'replace';
+}
+
+function isSignedOperation(operation: Operation): operation is SignedOperation {
+  return !isReplaceOperation(operation) || 'hash' in operation;
+}
+
+export class PatchVerifier {
+  private waitlist: { [address: string]: string } = {};
+
+  public signOperation(operation: Operation): SignedOperation {
+    if (isReplaceOperation(operation)) {
+      const hash = Math.random().toString(36).substring(2, 15);
+      const path = operation.path;
+      this.waitlist[path] = hash;
+
+      return { ...operation, hash };
+    } else {
+      return operation;
+    }
+  }
+
+  public sign(patch: Patch) {
+    return patch.map(op => this.signOperation(op));
+  }
+
+  public isVerifiedOperation(operation: Operation): boolean {
+    if (
+      isReplaceOperation(operation)
+      && isSignedOperation(operation)
+      && operation.path in this.waitlist
+    ) {
+      if (this.waitlist[operation.path] === operation.hash) {
+        delete this.waitlist[operation.path];
+      }
+
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  public verified(patch: Patch): Patch {
+    return patch.filter(op => this.isVerifiedOperation(op));
+  }
+}


### PR DESCRIPTION
## Summary

With current implementation of realtime collaboration, there was an issue of self-stuttering. This PR suppresses such stuttering by signing issued change operations and locally discarding broadcast changes that a client optimistically anticipates will be overwritten.

## Problem Description

Current implementation of realtime collaboration relies on strongly idempotent changes being broadcast by clients, temporally sorted by the server and re-broadcast to all clients (including the client who issued the change initially).

- Changes are strongly idempotent: a client applying a change would get the same result regardless of whether they have already, at some point in the past, applied the change or not, or how many times.
- This yields eventual consistency, as each client in the end applies the same sequence of changes, broadcast by the server, overriding changes they have applied locally.

While this provides a simple and straight-forward solution for achieving eventual consistency, it has a "self-stuttering" side effect:

1. client A applies change X locally, then broadcasts it
2. client B applies change Y locally, then broadcasts it. change Y has the same scope as change X.
3. both clients receive change X from the server and (re)apply it. Both their local states becomes the result of change X.
4. both clients receive change Y from the server and (re)apply it. Both their local states becomes the result of change Y.

In this scenario, client A observes the state change as `I -> X -> X -> Y`. Since reapplying a change doesn't affect the state (idempotency), this is equivalent to observing the state sequence `I -> X -> Y`, which is correct.

Client B however, observes the sequence `I -> Y -> X -> Y`, i.e. the state changing and then reverting again (_stuttering_). I call this _self-stuttering_ because it is caused by them eagerly applying changes originated by themself (change Y). The desired sequence would be `I -> Y`.

This is particularly an issue as it can occur even without another client issuing changes on the same scope. Imagine the client issuing constant changes on the same scope (for example, by dragging an element). The following sequence of events is possible (and probable):

1. The client issues change X.
2. The client issues change Y.
3. The server broadcasts change X, the client (re)applies it.
4. The server broadcasts change Y, the client (re)applies it.

In this scenario, the client will observe the state sequence `I -> X -> Y -> X -> Y`, without interference from any other collaboration peer.

## Solution Details

The solution relies on each client optimistically assessing whether an incoming change from the server would be overridden by a following change in near future or not.

- In reliable network conditions, a client can assume that any change they broadcast will be broadcast back at some point in near future.
- Subsequently, if they receive another change on the same scope from the server before receiving their own change, they can assume that it will be overridden in near future.
- The client can hence keep track of changes they have issued for a scope and discard incoming changes on that scope until they receive their own issued change.

In case of current implementation, [JSON Patch's replace operation](https://jsonpatch.com/#replace) is not only strongly idempotent, but also the main cause of self-stuttering. Its scope can be tracked by each client by tracking changes done to a certain `path`. To ensure the same change is broadcast back by the server, each client can sign each operation with a unique hash and check the hash of incoming operations.

A `PatchVerifier` utility class has been added for this purpose:

```ts
// webapp/src/main/utils/patch-verifier.ts

export class PatchVerifier {
  public signOperation(op: Operation): SignedOperation;
  public sign(patch: Patch): SignedPatch;

  public isVerifiedOperation(op: Operation): boolean;
  public verified(patch: Patch): Patch;
}
```

`signOperation()` method checks if the operation is a replace operation, and in that case signs it with a unique hash and records its `path` and `hash` pair in a mapping. `sign()` signs all operations inside a patch.

`isVerifiedOperation()` checks whether some incoming operation is a signed replace operation or not. If it is, it checks whether its `path` is recorded in the aforementioned mapping. If not, then it verifies the operation (it can be applied without causing stuttering), otherwise it denies the operation (it can be optimistically discarded). If the `hash` of a signed replace operation with a matching `path` also matches, then the client has received its own issued change back from the server, and the `path, hash` pair is removed from the mapping (following changes on the path will be verified and applied).

`verified()` method clears up a patch, leaving only verified operations.

