### PR TITLE
add support for atomic saves

### DIFF
--- a/packages/server/src/main/services/collaboration-service/collaboration-service.ts
+++ b/packages/server/src/main/services/collaboration-service/collaboration-service.ts
@@ -3,7 +3,6 @@ import { randomString } from '../../utils';
 import { DiagramFileStorageService } from '../diagram-storage/diagram-file-storage-service';
 import { Collaborator } from 'shared/src/main/collaborator-dto';
 import { SelectionChange } from 'shared/src/main/selection-dto';
-import { applyPatch } from 'fast-json-patch';
 import { Patch } from '@ls1intum/apollon';
 
 type Client = { token: string; collaborator: Collaborator };
@@ -120,9 +119,10 @@ export class CollaborationService {
   };
 
   onDiagramPatch = async (socket: any, token: string, patch: Patch, collaborator: Collaborator) => {
-    const diagram = await this.diagramService.getDiagramByLink(token);
-    diagram!.model = applyPatch(diagram!.model, patch).newDocument;
-    this.diagramService.saveDiagram(diagram!, token, true);
+    await this.diagramService.patchDiagram(token, patch);
+    // const diagram = await this.diagramService.getDiagramByLink(token);
+    // diagram!.model = applyPatch(diagram!.model, patch).newDocument;
+    // this.diagramService.saveDiagram(diagram!, token, true);
 
     const tokenClients = this.getTokenClients(socket.apollonId, false);
     this.clients[socket.apollonId] = { token, collaborator };

--- a/packages/server/src/main/services/diagram-storage/diagram-storage-service.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-storage-service.ts
@@ -1,6 +1,9 @@
 import { DiagramDTO } from 'shared/src/main/diagram-dto';
+import { Operation } from 'fast-json-patch';
 
 export interface DiagramStorageService {
   saveDiagram(diagramDTO: DiagramDTO, token: string): Promise<string>;
   getDiagramByLink(token: string): Promise<DiagramDTO | undefined>;
+  patchDiagram(token: string, patch: Operation[]): Promise<void>;
+  diagramExists(token: string): Promise<boolean>;
 }


### PR DESCRIPTION
Previously, diagram saves (for example, during realtime collaboration) would follow these steps:

1. The server would receive a change from a client
2. The server would load the diagram
3. The server would apply the changes
4. The server would save the diagram and broadcast the changes

Since updating diagrams was not atomic, there was a potential for clashes while updating a diagram: for example an update could be initiated by another client while the server is between steps 2 and 4, resulting in corrupted stored data.

This PR changes the process to enable atomic updates, resolving this issue:

1. The server will receive a change from a client
2. The server atomically updates the diagram
3. The server broadcasts the change

The `DiagramStorageService` interface is updated with two additional methods:

```ts
export interface DiagramStorageService {
  saveDiagram(diagramDTO: DiagramDTO, token: string): Promise<string>;
  getDiagramByLink(token: string): Promise<DiagramDTO | undefined>;

  // 👇 these methods are added via this PR
  patchDiagram(token: string, patch: Operation[]): Promise<void>;
  diagramExists(token: string): Promise<boolean>;
}
```

`DiagramFileStorageService` provides implementations for both of these methods. It will rate limit calls to `saveDiagram()` and calls to `patchDiagram()` in a single queue, as the purpose of the rate limiting is to avoid frequently modifying the diagram files on the filesystem regardless of the nature of the change (i.e. a patch will be overwritten by a following save and vice-versa, so they should be debounced w.r.t. each other).