### PR TITLE
Track diagram creation including diagram type

### DIFF
--- a/packages/webapp/src/main/components/modals/create-diagram-modal/create-diagram-modal.tsx
+++ b/packages/webapp/src/main/components/modals/create-diagram-modal/create-diagram-modal.tsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { ApplicationState } from '../../store/application-state';
 import { DiagramRepository } from '../../../services/diagram/diagram-repository';
 import { ModalContentProps } from '../application-modal-types';
+import posthog from 'posthog-js';
 
 type OwnProps = {} & ModalContentProps;
 
@@ -63,6 +64,12 @@ class CreateDiagramModalComponent extends Component<Props, State> {
 
   createNewDiagram() {
     this.props.createDiagram(this.state.diagramTitle, this.state.selectedDiagramType as UMLDiagramType);
+
+    posthog.capture('diagram_created', {
+      title: this.state.diagramTitle,
+      type: this.state.selectedDiagramType,
+    });
+
     this.props.close();
   }
 


### PR DESCRIPTION
This PR adds support for tracking when a new diagram is created and which type of diagram is created to PostHog.