### PR TITLE
Add Smart App Banner to promote newly released iOS app

### DIFF
--- a/packages/webapp/src/main/index.html
+++ b/packages/webapp/src/main/index.html
@@ -5,6 +5,7 @@
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
+    <meta name="apple-itunes-app" content="app-id=6474762031">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
To promote the newly released iOS app for Apollon, this PR adds a smart app banner to index.html of the web app.

![IMG_8668](https://github.com/ls1intum/Apollon_standalone/assets/9954674/0f88d0b5-4e25-4183-80db-bc1c489b51ef)
