### PR TITLE
add redis storage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,31 @@ useful command to debug:
 docker run -it --entrypoint /bin/bash apollon_standalone
 ```
 
+## Redis Storage
+
+Alternative to a filesystem, the application server can use a Redis database to store the shared diagrams.
+To use Redis, set the environment variable `APOLLON_REDIS_URL` to the URL of the Redis database.
+
+> [!IMPORTANT]
+> Apollon Standalone requires the Redis JSON module to be enabled. [Read the documents](https://redis.io/docs/latest/develop/data-types/json/) to learn how to enable the JSON module.
+
+
+```bash
+APOLLON_REDIS_URL=redis://[[username]:[password]@][host][:port]
+```
+
+For example:
+
+```bash
+export APOLLON_REDIS_URL=redis://alice:foobared@awesome.redis.server:6380
+```
+
+You can also set the `REDIS_URL` to an empty string, in which case `localhost:6379` will be used as the default.
+
+```bash
+export APOLLON_REDIS_URL=""
+```
+
 ## Developer Setup
 
 ```
@@ -257,3 +282,18 @@ For more information please refer to the [documentation](https://docs.npmjs.com/
 >
 > -   Recompile the Apollon project by executing `npm run prepare`
 > -   Rebuild the Standalone project by executing `npm run build`
+
+### Using Redis in Development
+
+To use Redis in development, you can use the following commands:
+
+```bash
+docker run -p 6379:6379 -it redis/redis-stack-server:latest
+```
+
+This runs the Redis stack, which also includes the Redis JSON module. You can now instruct
+Apollon Standalone to use Redis by setting the `APOLLON_REDIS_URL` environment variable.
+
+```bash
+APOLLON_REDIS_URL="" npm start
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2334,6 +2334,64 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.14.tgz",
+      "integrity": "sha512-YGn0GqsRBFUQxklhY7v562VMOP0DcmlrHHs3IV1mFE3cbxe31IITUkqhBcIhVSI/2JqtWAJXg5mjV4aU+zD0HA==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.6.tgz",
+      "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.1.6.tgz",
+      "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz",
+      "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@redux-saga/core": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.3.0.tgz",
@@ -4233,6 +4291,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -6402,6 +6468,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -9442,6 +9516,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.13.tgz",
+      "integrity": "sha512-MHgkS4B+sPjCXpf+HfdetBwbRz6vCtsceTmw1pHNYJAsYxrfpOP6dz+piJWGos8wqG7qb3vj/Rrc5qOlmInUuA==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.14",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
       }
     },
     "node_modules/redux": {
@@ -12516,6 +12603,7 @@
         "global-jsdom": "9.2.0",
         "jsdom": "23.2.0",
         "pdfmake": "0.2.10",
+        "redis": "4.6.13",
         "rxjs": "7.8.1",
         "shared": "2.1.3"
       },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "jsdom": "23.2.0",
     "pdfmake": "0.2.10",
     "rxjs": "7.8.1",
+    "redis": "4.6.13",
     "shared": "2.1.3"
   },
   "devDependencies": {

--- a/packages/server/src/main/resources/diagram-resource.ts
+++ b/packages/server/src/main/resources/diagram-resource.ts
@@ -5,10 +5,10 @@ import pdfMake from 'pdfmake/build/pdfmake.min';
 import pdfFonts from 'pdfmake/build/vfs_fonts';
 import { DiagramDTO } from 'shared/src/main/diagram-dto';
 import { DiagramService } from '../services/diagram-service/diagram-service';
-import { DiagramFileStorageService } from '../services/diagram-storage/diagram-file-storage-service';
+import { DiagramStorageFactory } from '../services/diagram-storage';
 
 export class DiagramResource {
-  diagramService: DiagramService = new DiagramService(new DiagramFileStorageService());
+  diagramService: DiagramService = new DiagramService(DiagramStorageFactory.getStorageService());
 
   getDiagram = (req: Request, res: Response) => {
     const tokenValue: string = req.params.token;

--- a/packages/server/src/main/services/collaboration-service/collaboration-service.ts
+++ b/packages/server/src/main/services/collaboration-service/collaboration-service.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 import { randomString } from '../../utils';
-import { DiagramFileStorageService } from '../diagram-storage/diagram-file-storage-service';
+import { DiagramStorageFactory, DiagramStorageService } from '../diagram-storage';
 import { Collaborator } from 'shared/src/main/collaborator-dto';
 import { SelectionChange } from 'shared/src/main/selection-dto';
 import { Patch } from '@ls1intum/apollon';
@@ -10,11 +10,11 @@ type Client = { token: string; collaborator: Collaborator };
 export class CollaborationService {
   private wsServer: any;
   private clients: { [key: string]: Client } = {};
-  private diagramService: DiagramFileStorageService;
+  private diagramService: DiagramStorageService;
   private readonly interval: NodeJS.Timeout;
   constructor() {
     this.wsServer = new WebSocket.Server({ noServer: true });
-    this.diagramService = new DiagramFileStorageService();
+    this.diagramService = DiagramStorageFactory.getStorageService();
     this.interval = setInterval(() => {
       this.wsServer.clients.forEach((ws: any) => {
         if (ws.isAlive === false) {

--- a/packages/server/src/main/services/diagram-storage/diagram-redis-storage-service.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-redis-storage-service.ts
@@ -1,0 +1,145 @@
+import { Operation } from 'fast-json-patch';
+import { RedisClientType, createClient } from 'redis';
+
+import { DiagramDTO } from '../../../../../shared/src/main/diagram-dto';
+import { DiagramStorageService } from './diagram-storage-service';
+import { DiagramStorageRateLimiter, DiagramStorageRequest } from './diagram-storage-rate-limiter';
+import { applyPatchToRedisValue } from './redis-patch';
+
+type SaveRequest = DiagramStorageRequest & {
+  key: string;
+}
+
+
+/**
+ * Diagram storage service that uses Redis as a storage backend.
+ */
+export class DiagramRedisStorageService implements DiagramStorageService {
+  /**
+   * How long should a substream for handling save requests of a particular
+   * diagram be kept alive. Recommended value is larger that SAVE_INTERVAL.
+   */
+  static readonly SAVE_GROUP_TTL = 10_000;
+  /**
+   * How long should we wait for incoming save requests before saving the diagram.
+   */
+  static readonly SAVE_DEBOUNCE_TIME = 10;
+  /**
+   * How often should we save the diagram to ensure we don't lose data.
+   * Saves might occur at a faster rate, this determines the maximum wait
+   * between two saves (when there are save requests).
+   */
+  static readonly SAVE_INTERVAL = 100;
+
+  /**
+   * The Redis client to use for storing diagrams.
+   */
+  redisClient: Promise<RedisClientType>;
+
+  /**
+   * The rate limiter for saving diagrams.
+   */
+  private limiter: DiagramStorageRateLimiter<SaveRequest>;
+
+  /**
+   * @param redisUrl the URL to connect to the Redis server. see
+   *               [the documentation of `redis` package](https://www.npmjs.com/package/redis#usage)
+   *               for more information on the URL format.
+   */
+  constructor(redisUrl?: string) {
+    this.redisClient = this.createRedisClient(redisUrl);
+    this.limiter = new DiagramStorageRateLimiter<SaveRequest>(
+      async (request) => {
+        const client = await this.redisClient;
+        await client.json.set(request.key, '$', request.diagramDTO as any);
+      },
+      async (request) => {
+        const client = await this.redisClient;
+        await applyPatchToRedisValue(client, request.key, request.patch, '$.model');
+      },
+      {
+        saveInterval: DiagramRedisStorageService.SAVE_INTERVAL,
+        saveDebounceTime: DiagramRedisStorageService.SAVE_DEBOUNCE_TIME,
+        saveGroupTTL: DiagramRedisStorageService.SAVE_GROUP_TTL,
+      },
+    );
+  }
+
+  async saveDiagram(diagramDTO: DiagramDTO, token: string, shared: boolean = false): Promise<string> {
+    const key = this.getKeyForToken(token);
+    const exists = await this.diagramExists(key);
+
+    if (exists && !shared) {
+      throw Error(`Diagram at ${key} already exists`);
+    } else {
+      if (exists) {
+        this.limiter.request({ diagramDTO, token, key });
+      } else {
+        const client = await this.redisClient;
+        const res = await client.json.set(key, '$', diagramDTO as any);
+        console.log(res);
+      }
+
+      return token;
+    }
+  }
+
+  async patchDiagram(token: string, patch: Operation[]): Promise<void> {
+    const key = this.getKeyForToken(token);
+    const exists = await this.diagramExists(token);
+
+    if (!exists) {
+      throw Error(`Diagram at ${key} does not exist`);
+    } else {
+      this.limiter.request({ patch, token, key });
+    }
+  }
+
+  async diagramExists(token: string): Promise<boolean> {
+    const key = this.getKeyForToken(token);
+    const client = await this.redisClient;
+
+    return await client.exists(key) > 0;
+  }
+
+  async getDiagramByLink(token: string): Promise<DiagramDTO | undefined> {
+    const key = this.getKeyForToken(token);
+    const client = await this.redisClient;
+    try {
+      const diagram = await client.json.get(key);
+
+      if (!diagram) {
+        return undefined;
+      }
+
+      return diagram as any as DiagramDTO;
+    } catch (err) {
+      console.log(`Can't load diagram ${key}:: `, err);
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the redis key to use for a diagram with given token.
+   */
+  private getKeyForToken(token: string): string {
+    return `apollon_diagram:${token}`;
+  }
+
+  /**
+   * Creates a Redis client and connects to the server.
+   */
+  private async createRedisClient(url?: string): Promise<RedisClientType> {
+    try {
+      console.log('Creating Redis client, connecting to:', url);
+      const client: RedisClientType = createClient(url ? { url } : undefined);
+      await client.connect();
+      console.log('Redis client connected');
+
+      return client;
+    } catch (err) {
+      console.log('Failed to create Redis client', err);
+      throw err;
+    }
+  }
+}

--- a/packages/server/src/main/services/diagram-storage/diagram-storage-rate-limiter.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-storage-rate-limiter.ts
@@ -1,0 +1,187 @@
+import { Operation } from 'fast-json-patch';
+import { DiagramDTO } from 'shared/src/main/diagram-dto';
+import { debounceTime, from, groupBy, mergeMap, Observable, Subject, switchMap } from 'rxjs';
+import { auditDebounceTime } from 'audit-debounce';
+
+
+/**
+ * Request for saving or patching a diagram.
+ */
+export interface DiagramPresistenceRequest {
+  token: string;
+}
+
+/**
+ * Request for saving a diagram.
+ */
+export interface DiagramSaveRequest extends DiagramPresistenceRequest {
+  /**
+   * The diagram to save.
+   */
+  diagramDTO: DiagramDTO;
+}
+
+/**
+ * Request for patching a diagram.
+ */
+export interface DiagramPatchRequest extends DiagramPresistenceRequest {
+  /**
+   * The patch to apply to the diagram, in format of [JSONPatch](https://jsonpatch.com).
+   */
+  patch: Operation[];
+}
+
+export type DiagramStorageRequest = DiagramSaveRequest | DiagramPatchRequest;
+
+/**
+ * Determines if the given persistence request is a save request.
+ */
+export function isDiagramSaveRequest(request: DiagramPresistenceRequest): request is DiagramSaveRequest {
+  return (request as DiagramSaveRequest).diagramDTO !== undefined;
+}
+
+/**
+ * Determines if the given persistence request is a patch request.
+ */
+export function isDiagramPatchRequest(request: DiagramPresistenceRequest): request is DiagramPatchRequest {
+  return (request as DiagramPatchRequest).patch !== undefined;
+}
+
+/**
+ * Configuration for the diagram storage rate limiter.
+ */
+export interface DiagramStorageRateLimiterConfig {
+  /**
+   * The interval at which the diagram should be saved, in milliseconds.
+   * When changes happen to the diagram, two save (or patch) operations will be a maximum
+   * of `saveInterval` milliseconds apart.
+   */
+  saveInterval: number;
+
+  /**
+   * The time to wait after the last save (or patch) request
+   * before storing the diagram. This is to prevent overloading the storage system.
+   * Diagrams will however be saved every `saveInterval` milliseconds to ensure
+   * data is not lost. This value should be less than `saveInterval`.
+   */
+  saveDebounceTime: number;
+
+  /**
+   * The time to keep a request group alive after the last persistence request
+   * for the group. Requests for the same diagram are grouped together. It is recommended to
+   * set this at a higher value than `saveInterval`.
+   */
+  saveGroupTTL: number;
+}
+
+/**
+ * Denotes a function that can save a diagram. Return an observable when each operation
+ * can be cancelled, so that the limiter cancels pending operations before initiating a new one.
+ */
+export type SaveDiagramFunction<T extends DiagramStorageRequest> =
+  (request: T & DiagramSaveRequest) => Promise<void> | Observable<void>;
+
+/**
+ * Denotes a function that can patch a diagram. Return an observable when each operation
+ * can be cancelled, so that the limiter cancels pending operations before initiating a new one.
+ */
+export type PatchDiagramFunction<T extends DiagramStorageRequest> =
+  (request: T & DiagramPatchRequest) => Promise<void> | Observable<void>;
+
+/**
+ * A rate limiter for saving diagrams. This limiter ensures that persistence requests
+ * do not overload the storage system.
+ */
+export class DiagramStorageRateLimiter<T extends DiagramStorageRequest> {
+  //
+  // this router handles saving of diagrams.
+  // requests for saving diagrams can come at any time, and might
+  // need some pacing to avoid overloading the file system (which results in corrupted files.
+  //
+  private router = new Subject<T>();
+
+  /**
+   * @param saveDiagram the function to save a diagram. The function should return an observable
+   *                     when the operation can be cancelled, so that the limiter cancels pending
+   *                    operations before initiating a new one.
+   * @param patchDiagram the function to patch a diagram. The function should return an observable
+   *                    when the operation can be cancelled, so that the limiter cancels pending
+   *                   operations before initiating a new one.
+   * @param config the configuration for the rate limiter, determining the rate at which diagrams are
+   *              saved or patched.
+   */
+  constructor(
+    saveDiagram: SaveDiagramFunction<T>,
+    patchDiagram: PatchDiagramFunction<T>,
+    readonly config: DiagramStorageRateLimiterConfig
+  ) {
+    //
+    // I do realize complex rxjs pipelines are not the easiest to read.
+    // so I will try to explain what is going on here.
+    //
+    this.router
+      .pipe(
+        //
+        // first, we group requests by token, since we don't want
+        // save requests for one token to affect requests of another
+        // token on the server (each token relates to a different diagram)
+        //
+        groupBy((request) => request.token, {
+          //
+          // this duration selector determines how long the "group" stream
+          // should be kept alive. without a duration selector, these "groups"
+          // will be kept alive indefinitely, clogging up memory.
+          //
+          duration: (group) =>
+            group.pipe(
+              //
+              // indicates that each group should be kept alive
+              // SAVE_GROUP_TTL milliseconds after the last save request for that
+              // group. note that the diagram might still be worked on,
+              // but we can create a new group for new save requests if they happen.
+              //
+              debounceTime(config.saveDebounceTime),
+            ),
+        }),
+        //
+        // with `mergeMap()`, we will operate on each "group" independently
+        // and then merge the results back into a singular stream.
+        //
+        mergeMap((group) =>
+          group.pipe(
+            //
+            // this will try to wait for SAVE_DEBOUNCE_TIME milliseconds
+            // after each incoming save request before saving the diagram.
+            // since that can be too long if save requests are incoming frequently,
+            // we will also save the diagram every SAVE_INTERVAL milliseconds to ensure
+            // we don't lose data (in case the server process stops, for example due to a crash).
+            //
+            auditDebounceTime(config.saveDebounceTime, config.saveInterval),
+            //
+            // since saving is an async operation itself, we need to use `switchMap()`
+            // to ensure only a single save operation is running at any given time.
+            //
+            switchMap((request) => {
+              if (isDiagramSaveRequest(request)) {
+                return from(saveDiagram(request));
+              } else if (isDiagramPatchRequest(request)) {
+                return from(patchDiagram(request));
+              } else {
+                return from(Promise.resolve());
+              }
+            }),
+          ),
+        ),
+      )
+      .subscribe();
+  }
+
+  /**
+   * Request to save or patch a diagram. The limiter will
+   * schedule this operation according to previous and subsequent requests,
+   * ensuring that the storage system is not overloaded.
+  */
+  request(request: T) {
+    this.router.next(request);
+  }
+}

--- a/packages/server/src/main/services/diagram-storage/diagram-storage-service.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-storage-service.ts
@@ -1,9 +1,32 @@
 import { DiagramDTO } from 'shared/src/main/diagram-dto';
 import { Operation } from 'fast-json-patch';
 
+/**
+ * Service for storing and retrieving diagrams.
+ */
 export interface DiagramStorageService {
+  /**
+   * Saves given diagram with given token.
+   * @param diagramDTO the diagram to save
+   * @param token the token to save the diagram with
+   */
   saveDiagram(diagramDTO: DiagramDTO, token: string): Promise<string>;
-  getDiagramByLink(token: string): Promise<DiagramDTO | undefined>;
+
+  /**
+   * Updates the diagram with the given token with the given patch.
+   * @param token the token of the diagram to update
+   * @param patch the patch to apply to the diagram (in format of [JSONPatch](https://jsonpatch.com))
+   */
   patchDiagram(token: string, patch: Operation[]): Promise<void>;
+
+  /**
+   * Returns a stored diagram by its token.
+   * @param token the token of the diagram to retrieve
+   */
+  getDiagramByLink(token: string): Promise<DiagramDTO | undefined>;
+
+  /**
+   * Checks if a diagram with the given token exists.
+   */
   diagramExists(token: string): Promise<boolean>;
 }

--- a/packages/server/src/main/services/diagram-storage/index.ts
+++ b/packages/server/src/main/services/diagram-storage/index.ts
@@ -1,0 +1,34 @@
+export { DiagramStorageService } from './diagram-storage-service';
+
+import { DiagramStorageService } from './diagram-storage-service';
+import { DiagramRedisStorageService } from './diagram-redis-storage-service';
+import { DiagramFileStorageService } from './diagram-file-storage-service';
+
+
+/**
+ * Factory for creating a diagram storage service. Will determine
+ * the correct service to use based on the environment.
+ */
+export class DiagramStorageFactory {
+  private static storageService?: DiagramStorageService;
+
+  private static createStorageService(): DiagramStorageService {
+    if (process.env.APOLLON_REDIS_URL !== undefined) {
+      return new DiagramRedisStorageService(process.env.REDIS_URL);
+    } else {
+      return new DiagramFileStorageService();
+    }
+  }
+
+  /**
+   * Returns the instance for diagram storage service.
+   * - If the environment variable `APOLLON_REDIS_URL` is set, it will return a `DiagramRedisStorageService`.
+   * - Otherwise, it will return a `DiagramFileStorageService`, which requires `/diagrams` directory to be present.
+   */
+  public static getStorageService(): DiagramStorageService {
+    if (this.storageService === undefined) {
+      this.storageService = this.createStorageService();
+    }
+    return this.storageService;
+  }
+}

--- a/packages/server/src/main/services/diagram-storage/redis-patch.ts
+++ b/packages/server/src/main/services/diagram-storage/redis-patch.ts
@@ -1,0 +1,48 @@
+import { RedisClientType } from 'redis';
+import { Operation } from 'fast-json-patch';
+
+
+/**
+ * Converts a [JSONPointer](https://tools.ietf.org/html/rfc6901) to a Redis JSON path.
+ * JSONPointer is the standard format for addressing various parts of a JSON document used by
+ * [JSONPatch](https://jsonpatch.com).
+ * @param jsonPointer 
+ * @returns 
+ */
+export function convertJSONPointerToRedisJSONPath(jsonPointer: string): string {
+  return jsonPointer
+    .replace(/\//g, '.')
+    .replace(/~1/g, '/')
+    .replace(/~0/g, '~');
+}
+
+/**
+ * Applies a JSONPatch to a Redis JSON value.
+ * @param client the Redis client to use
+ * @param key the key of the Redis value
+ * @param patch the JSONPatch to apply
+ * @param prefix the prefix to use for the JSON path. Defaults to `'$'`, i.e. the root of the document. Add another prefix to apply the patch to a nested object. For example, if patches are to be applied to `model` field of an object, use `'$.model'`. The prefix should be in format of [redis JSON path](https://redis.io/docs/latest/develop/data-types/json/path/).
+ */
+export async function applyPatchToRedisValue(client: RedisClientType, key: string, patch: Operation[], prefix = '$') {
+  for (const operation of patch) {
+    const path = prefix + convertJSONPointerToRedisJSONPath(operation.path);
+
+    try {
+      switch (operation.op) {
+        case 'add':
+        case 'replace':
+            await client.json.set(key, path, operation.value);
+          break;
+        case 'remove':
+          await client.json.del(key, path);
+          break;
+        default:
+          throw Error(`Unsupported operation ${operation.op}`);
+      }
+    } catch (err) {
+      console.log(`Can't apply patch ${operation.op} to ${key}:: `, err);
+      console.log('On Redis path: ' + path);
+      console.log(err);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for using Redis as the storage service of Apollon Standalone (instead of file-based storage). After merging this PR, Apollon Standalone will look for `APOLLON_REDIS_URL` environment variable, and if present, switch to Redis as its storage backend. See [these docs](https://www.npmjs.com/package/redis#usage) for further info on the format of the Redis URL. If the environment variable is not present, Apollon Standalone will fallback into using the filesystem based storage it was already using.


The main benefit of using Redis as the storage backend is stability of high-frequency writes. Specifically in context of realtime collaboration, it can happen that diagrams are constantly updated, which, using a file based storage, means potentially colliding write operations resulting in corrupted files. The `DiagramFileStorageService` was already equipped with rate-limiting logic to mitigate this issue, but this means occasionally clients would get the wrong diagram if they requested it at the wrong time (for example, while a change is being debounced).

This PR refactors the rate limiting logic into a separate `DiagramStorageRateLimiter` class, which is in turn used by both the old `DiagramFileStorageService` and the new `DiagramRedisStorageService`. However, the Redis storage service can use a much more relaxed rate limiting configuration as Redis is much faster than a file-based storage scheme. Additionally, Redis, through its [JSON](https://redis.io/docs/latest/develop/data-types/json/) module, allows for atomic patching of diagrams, which was again not possible in a file-based storage, further increasing the stability and performance of the storage.