### PR TITLE
Support deployment with Redis using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install
 RUN npm run build
 
 # second stage which creates the container image to run the application
-FROM node:16
+FROM node:18
 
 RUN apt-get update && apt-get -y install cron
 

--- a/Dockerfile.redis
+++ b/Dockerfile.redis
@@ -1,0 +1,23 @@
+FROM node:22-alpine
+RUN apk add --no-cache \
+  build-base \
+  g++ \
+  cairo-dev \
+  jpeg-dev \
+  pango-dev \
+  giflib-dev
+
+ENV APOLLON_REDIS_URL=""
+ENV DEPLOYMENT_URL="http://localhost:8080"
+
+WORKDIR /app
+
+COPY . .
+RUN npm install
+RUN npm run build
+
+WORKDIR /app/build/server
+
+EXPOSE 8080
+
+CMD [ "node", "bundle.js" ]

--- a/README.md
+++ b/README.md
@@ -236,11 +236,54 @@ For example:
 export APOLLON_REDIS_URL=redis://alice:foobared@awesome.redis.server:6380
 ```
 
-You can also set the `REDIS_URL` to an empty string, in which case `localhost:6379` will be used as the default.
+You can also set the `APOLLON_REDIS_URL` to an empty string, in which case `localhost:6379` will be used as the default.
 
 ```bash
 export APOLLON_REDIS_URL=""
 ```
+
+You can also set `APOLLON_REDIS_DIAGRAM_TTL` environment variable to set the time-to-live for the shared diagrams in Redis. If not provided, shared diagrams will be stored indefinitely. The specified duration is parsed using the [ms](https://www.npmjs.com/package/ms) package, so you can use human-readable strings like `1d`, `2h`, `30m`, etc.
+
+```bash
+export APOLLON_REDIS_DIAGRAM_TTL="30d"
+```
+
+### Deploying with Redis and Docker
+
+Apollon Standalone can be deployed using Docker and connected to another Docker container running Redis.
+
+**STEP 1**: Create a Docker network.
+```bash
+docker network create apollon_network
+```
+
+**STEP 2**: Run the Redis container.
+```bash
+docker run -d --name apollon_redis --network apollon_network redis/redis-stack-server:latest
+```
+
+**STEP 3**: Build the Apollon Standalone Docker container.
+```bash
+docker build -t apollon_standalone -f ./Dockerfile.redis .
+```
+
+> [!IMPORTANT]
+> The Dockerfile for Apollon Standalone using Redis is seperate from the default Dockerfile. Make sure that you build the correct Dockerfile, i.e. `Dockerfile.redis`.
+
+**STEP 4**: Run the Apollon Standalone Docker container.
+```bash
+docker run -d \
+  --name apollon_standalone-0 \
+  --network apollon_network \
+  -e APOLLON_REDIS_URL=redis://apollon_redis:6379 \
+  -p 8080:8080 apollon_standalone
+```
+
+> [!NOTE]
+> Running Redis in a container on the same network is a secure method of deploying Redis. If you have Redis running via some other means, simply provide `APOLLON_REDIS_URL` with the correct URL.
+
+> [!NOTE]
+> Provide `APOLLON_REDIS_DIAGRAM_TTL` environment variable to set the time-to-live for the shared diagrams in Redis. If not provided, shared diagrams will be stored indefinitely.
 
 ## Developer Setup
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ docker run -d \
 > [!NOTE]
 > Provide `APOLLON_REDIS_DIAGRAM_TTL` environment variable to set the time-to-live for the shared diagrams in Redis. If not provided, shared diagrams will be stored indefinitely.
 
+> [!NOTE]
+> Do not forget to set the `DEPLOYMENT_URL` environment variable to the URL of the deployed application, when deploying to production environments.
+
 ## Developer Setup
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -3004,6 +3004,12 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.10.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
@@ -4963,6 +4969,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decimal.js": {
       "version": "10.4.3",
@@ -8317,9 +8328,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -9556,6 +9567,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
+    "node_modules/redux-saga": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.3.0.tgz",
+      "integrity": "sha512-J9RvCeAZXSTAibFY0kGw6Iy4EdyDNW7k6Q+liwX+bsck7QVsU78zz8vpBRweEfANxnnlG/xGGeOvf6r8UXzNJQ==",
+      "dependencies": {
+        "@redux-saga/core": "^1.3.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -10052,11 +10071,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -12593,7 +12607,7 @@
       "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
-        "@ls1intum/apollon": "3.3.12",
+        "@ls1intum/apollon": "3.3.14",
         "@sentry/node": "7.110.1",
         "audit-debounce": "0.1.1",
         "body-parser": "1.20.2",
@@ -12602,6 +12616,7 @@
         "express": "4.19.2",
         "global-jsdom": "9.2.0",
         "jsdom": "23.2.0",
+        "ms": "2.1.3",
         "pdfmake": "0.2.10",
         "redis": "4.6.13",
         "rxjs": "7.8.1",
@@ -12610,6 +12625,7 @@
       "devDependencies": {
         "@types/cors": "2.8.17",
         "@types/express": "4.17.21",
+        "@types/ms": "^0.7.34",
         "@types/node": "20.12.7",
         "@types/pdfmake": "0.2.9",
         "@typescript-eslint/eslint-plugin": "6.21.0",
@@ -13303,14 +13319,6 @@
         "node": ">=12"
       }
     },
-    "packages/server/node_modules/redux-saga": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.3.0.tgz",
-      "integrity": "sha512-J9RvCeAZXSTAibFY0kGw6Iy4EdyDNW7k6Q+liwX+bsck7QVsU78zz8vpBRweEfANxnnlG/xGGeOvf6r8UXzNJQ==",
-      "dependencies": {
-        "@redux-saga/core": "^1.3.0"
-      }
-    },
     "packages/server/node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -13425,7 +13433,7 @@
       "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
-        "@ls1intum/apollon": "3.3.12",
+        "@ls1intum/apollon": "3.3.14",
         "moment": "2.30.1",
         "ws": "8.16.0"
       },
@@ -13469,14 +13477,6 @@
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
-      }
-    },
-    "packages/shared/node_modules/redux-saga": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.3.0.tgz",
-      "integrity": "sha512-J9RvCeAZXSTAibFY0kGw6Iy4EdyDNW7k6Q+liwX+bsck7QVsU78zz8vpBRweEfANxnnlG/xGGeOvf6r8UXzNJQ==",
-      "dependencies": {
-        "@redux-saga/core": "^1.3.0"
       }
     },
     "packages/shared/node_modules/styled-components": {
@@ -13531,7 +13531,7 @@
     "packages/webapp": {
       "version": "2.1.3",
       "dependencies": {
-        "@ls1intum/apollon": "3.3.12",
+        "@ls1intum/apollon": "3.3.14",
         "@sentry/react": "7.110.1",
         "bootstrap": "5.3.3",
         "moment": "2.30.1",
@@ -14641,14 +14641,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "packages/webapp/node_modules/redux-saga": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.3.0.tgz",
-      "integrity": "sha512-J9RvCeAZXSTAibFY0kGw6Iy4EdyDNW7k6Q+liwX+bsck7QVsU78zz8vpBRweEfANxnnlG/xGGeOvf6r8UXzNJQ==",
-      "dependencies": {
-        "@redux-saga/core": "^1.3.0"
       }
     },
     "packages/webapp/node_modules/resolve": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ls1intum/apollon": "3.3.12",
+    "@ls1intum/apollon": "3.3.14",
     "@sentry/node": "7.110.1",
     "audit-debounce": "0.1.1",
     "body-parser": "1.20.2",
@@ -21,14 +21,16 @@
     "express": "4.19.2",
     "global-jsdom": "9.2.0",
     "jsdom": "23.2.0",
+    "ms": "2.1.3",
     "pdfmake": "0.2.10",
-    "rxjs": "7.8.1",
     "redis": "4.6.13",
+    "rxjs": "7.8.1",
     "shared": "2.1.3"
   },
   "devDependencies": {
     "@types/cors": "2.8.17",
     "@types/express": "4.17.21",
+    "@types/ms": "0.7.34",
     "@types/node": "20.12.7",
     "@types/pdfmake": "0.2.9",
     "@typescript-eslint/eslint-plugin": "6.21.0",

--- a/packages/server/src/main/services/diagram-storage/diagram-redis-storage-service.ts
+++ b/packages/server/src/main/services/diagram-storage/diagram-redis-storage-service.ts
@@ -1,3 +1,4 @@
+import ms from 'ms';
 import { Operation } from 'fast-json-patch';
 import { RedisClientType, createClient } from 'redis';
 
@@ -8,6 +9,27 @@ import { applyPatchToRedisValue } from './redis-patch';
 
 type SaveRequest = DiagramStorageRequest & {
   key: string;
+}
+
+
+/**
+ * Options for the Redis storage service.
+ */
+export interface RedisStorageOptions {
+  /**
+   * The URL to connect to the Redis server. see
+   * [the documentation of `redis` package](https://www.npmjs.com/package/redis#usage)
+   * for more information on the URL format.
+   */
+  url?: string;
+
+  /**
+   * The time-to-live for diagrams stored in Redis. If set, the diagram will
+   * be automatically deleted after the given time has passed since the last
+   * save operation. The value is parsed using the [`ms`](https://www.npmjs.com/package/ms)
+   * package, so you can use values like `1d`, `1h`, `30m`, etc.
+   */
+  ttl?: string;
 }
 
 
@@ -42,20 +64,20 @@ export class DiagramRedisStorageService implements DiagramStorageService {
   private limiter: DiagramStorageRateLimiter<SaveRequest>;
 
   /**
-   * @param redisUrl the URL to connect to the Redis server. see
-   *               [the documentation of `redis` package](https://www.npmjs.com/package/redis#usage)
-   *               for more information on the URL format.
+   * @param options Options for the Redis storage service.
    */
-  constructor(redisUrl?: string) {
-    this.redisClient = this.createRedisClient(redisUrl);
+  constructor(readonly options?: RedisStorageOptions) {
+    this.redisClient = this.createRedisClient(options?.url);
     this.limiter = new DiagramStorageRateLimiter<SaveRequest>(
       async (request) => {
         const client = await this.redisClient;
         await client.json.set(request.key, '$', request.diagramDTO as any);
+        await this.checkExpire(request.key);
       },
       async (request) => {
         const client = await this.redisClient;
         await applyPatchToRedisValue(client, request.key, request.patch, '$.model');
+        await this.checkExpire(request.key);
       },
       {
         saveInterval: DiagramRedisStorageService.SAVE_INTERVAL,
@@ -76,8 +98,8 @@ export class DiagramRedisStorageService implements DiagramStorageService {
         this.limiter.request({ diagramDTO, token, key });
       } else {
         const client = await this.redisClient;
-        const res = await client.json.set(key, '$', diagramDTO as any);
-        console.log(res);
+        await client.json.set(key, '$', diagramDTO as any);
+        await this.checkExpire(key);
       }
 
       return token;
@@ -119,6 +141,13 @@ export class DiagramRedisStorageService implements DiagramStorageService {
     }
   }
 
+  protected async checkExpire(key: string) {
+    if (this.options?.ttl) {
+      const client = await this.redisClient;
+      await client.expire(key, ms(this.options.ttl) / 1000);
+    }
+  }
+  
   /**
    * Returns the redis key to use for a diagram with given token.
    */

--- a/packages/server/src/main/services/diagram-storage/index.ts
+++ b/packages/server/src/main/services/diagram-storage/index.ts
@@ -14,7 +14,10 @@ export class DiagramStorageFactory {
 
   private static createStorageService(): DiagramStorageService {
     if (process.env.APOLLON_REDIS_URL !== undefined) {
-      return new DiagramRedisStorageService(process.env.REDIS_URL);
+      return new DiagramRedisStorageService({
+        url: process.env.APOLLON_REDIS_URL,
+        ttl: process.env.APOLLON_REDIS_DIAGRAM_TTL,
+      });
     } else {
       return new DiagramFileStorageService();
     }

--- a/packages/server/webpack/webpack.config.js
+++ b/packages/server/webpack/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = {
   },
   externals: {
     canvas: 'commonjs ./canvas/canvas',
-    bufferutil: 'bufferutil',
     'utf-8-validate': 'utf-8-validate',
   },
   plugins: [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@ls1intum/apollon": "3.3.12",
+    "@ls1intum/apollon": "3.3.14",
     "moment": "2.30.1",
     "ws": "8.16.0"
   },

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.17.0"
   },
   "dependencies": {
-    "@ls1intum/apollon": "3.3.12",
+    "@ls1intum/apollon": "3.3.14",
     "@sentry/react": "7.110.1",
     "bootstrap": "5.3.3",
     "moment": "2.30.1",


### PR DESCRIPTION
This PR will add a Dockerfile and instructions that enable deploying (locally or to a server) using Docker while using Redis as storage backend. To achieve this, I had to fix the following small issues as well:

- The build configuration was buggy (regardless of Docker), omitting essential packages from the server bundle which would not allow WebSockets to work.
- The default Dockerfile is out of date. I think in a follow-up PR the Dockerfile can be re-written and perhaps the two Dockerfiles can be merged, so connecting to Redis is solely controlled via environment variables passed to the container.
- Support for expiring shared diagrams stored on Redis was added. In the file-storage solution, a cron service was to be configured to ensure cleanup. For Redis, this can be achieved via a simple environment variable `APOLLON_REDIS_DIAGRAM_TTL`.