### PR TITLE
Invalidate GitHub cache so that embeddings are not cached

### DIFF
--- a/packages/server/src/main/resources/diagram-resource.ts
+++ b/packages/server/src/main/resources/diagram-resource.ts
@@ -28,7 +28,12 @@ export class DiagramResource {
                 '<svg$1 style="background-color: white;">',
               );
 
-              res.setHeader('Content-Type', 'image/svg+xml');
+              res.set({
+                'Content-Type': 'image/svg+xml',
+                'Cache-Control': 'no-cache',
+                Expires: new Date(Date.now() - 36000 * 1000).toUTCString(),
+              });
+
               return res.send(diagramSvgWhiteBackground);
             }
 


### PR DESCRIPTION
When returning a diagram, headers are set in the response so that the GitHub's CDN cache is invalidated. This ensures that diagram embeddings are not cached and therefore always up to date.

Idea from https://stackoverflow.com/a/27893930