### PR TITLE
Support embeddings on dark background

### DIFF
--- a/packages/server/src/main/resources/diagram-resource.ts
+++ b/packages/server/src/main/resources/diagram-resource.ts
@@ -22,11 +22,25 @@ export class DiagramResource {
         .then(async (diagram: DiagramDTO | undefined) => {
           if (diagram) {
             if (req.query.type === 'svg') {
-              const diagramSvg = (await this.conversionService.convertToSvg(diagram.model)).svg;
-              const diagramSvgWhiteBackground = diagramSvg.replace(
-                /<svg([^>]*)>/,
-                '<svg$1 style="background-color: white;">',
-              );
+              let diagramSvg = (await this.conversionService.convertToSvg(diagram.model)).svg;
+
+              // Makes connections and belonging text white, for visibility on a dark background
+              if (req.query.mode === 'dark') {
+                const whiteConnections = `
+                  [class=""] polyline {
+                    stroke: white;
+                  }
+
+                  [class=""] text {
+                    fill: white;
+                  }
+                `;
+
+                diagramSvg = diagramSvg.replace(/<style>([\s\S]*?)<\/style>/, (match, existingStyles) => {
+                  // Inserts the new CSS rules into the <style> tag
+                  return `<style>\n${existingStyles.trim()}\n${whiteConnections.trim()}\n</style>`;
+                });
+              }
 
               res.set({
                 'Content-Type': 'image/svg+xml',
@@ -34,7 +48,7 @@ export class DiagramResource {
                 Expires: new Date(Date.now() - 36000 * 1000).toUTCString(),
               });
 
-              return res.send(diagramSvgWhiteBackground);
+              return res.send(diagramSvg);
             }
 
             return res.json(diagram);

--- a/packages/webapp/src/main/components/modals/share-modal/share-modal.tsx
+++ b/packages/webapp/src/main/components/modals/share-modal/share-modal.tsx
@@ -30,7 +30,7 @@ export const ShareModal: React.FC<ModalContentProps> = ({ close }) => {
     if (LocalStorageRepository.getLastPublishedType() === DiagramView.EMBED) {
       return `![${
         diagram ? diagram.title : 'Diagram'
-      }](${DEPLOYMENT_URL}/api/diagrams/${LocalStorageRepository.getLastPublishedToken()}?type=svg)`;
+      }](${DEPLOYMENT_URL}/api/diagrams/${LocalStorageRepository.getLastPublishedToken()}?type=svg&mode=${LocalStorageRepository.getUserThemePreference() ?? 'light'})`;
     }
 
     return `${DEPLOYMENT_URL}/${token || LocalStorageRepository.getLastPublishedToken()}?view=${LocalStorageRepository.getLastPublishedType()}`;


### PR DESCRIPTION
This PR removes the white background from embeddings in case the editor was in dark mode at the time of sharing the diagram.