### PR TITLE
Fix pdf export

### DIFF
--- a/packages/server/src/main/routes.ts
+++ b/packages/server/src/main/routes.ts
@@ -22,10 +22,10 @@ export const register = (app: express.Application) => {
   router.get('/converter/status', (req, res) => conversionResource.status(req, res));
 
   // routes: diagrams
-  router.get('/diagrams/:token', (req, res) => diagramResource.getDiagram(req, res));
+  router.post('/diagrams/pdf', (req, res) => diagramResource.convertSvgToPdf(req, res));
   router.post('/diagrams/publish', (req, res) => diagramResource.publishDiagramVersion(req, res));
+  router.get('/diagrams/:token', (req, res) => diagramResource.getDiagram(req, res));
   router.delete('/diagrams/:token', (req, res) => diagramResource.deleteDiagramVersion(req, res));
   router.post('/diagrams/:token', (req, res) => diagramResource.editDiagramVersion(req, res));
-  router.post('/diagrams/pdf', (req, res) => diagramResource.convertSvgToPdf(req, res));
   app.use('/api', router);
 };


### PR DESCRIPTION
Fixing PDF export
Routing in server routes was not finding the correct endpoint for diagrams/pdf
Changing order makes API call to correct function

https://github.com/user-attachments/assets/07992b02-2411-49e5-aa97-f0f32a394d49

